### PR TITLE
Add support for exporting prometheus metrics

### DIFF
--- a/haproxy20.spec
+++ b/haproxy20.spec
@@ -82,6 +82,7 @@ regparm_opts="USE_REGPARM=1"
     ${regparm_opts} \
     ADDINC="%{optflags}" \
     ADDLIB="%{__global_ldflags}" \
+    EXTRA_OBJS="contrib/prometheus-exporter/service-prometheus.o"
 
 pushd contrib/halog
 %{__make} ${halog} OPTIMIZE="%{optflags} %{build_ldflags}"


### PR DESCRIPTION
I would like to use this rpm but need the Prometheus metrics exporter, which is contained in the upstream sources. Would it be an option to add this to the build?