### PR TITLE
HAProxy 2.0.23

### DIFF
--- a/haproxy20.spec
+++ b/haproxy20.spec
@@ -9,7 +9,7 @@
 %bcond_without lua
 
 Name:           haproxy20
-Version:        2.0.20
+Version:        2.0.23
 Release:        1%{?dist}
 Summary:        HAProxy reverse proxy for high availability environments
 
@@ -165,6 +165,9 @@ exit 0
 %{_mandir}/man1/*
 
 %changelog
+* Thu Aug  5 2021 Christian Boenning <christian@boenning.io> - 2.0.23-1
+- Upstream HAProxy 2.0.23
+
 * Mon Feb 01 2021 Christian Boenning <christian@boenning.io> - 2.0.20-1
 - Latest upstream
 

--- a/haproxy20.spec
+++ b/haproxy20.spec
@@ -34,7 +34,7 @@ BuildRequires:  lua-devel >= 5.3
 %endif
 BuildRequires:  pcre2-devel
 BuildRequires:  zlib-devel
-BuildRequires:  openssl-devel
+BuildRequires:  openssl11-devel
 BuildRequires:  systemd-devel
 BuildRequires:  systemd
 
@@ -72,6 +72,8 @@ regparm_opts="USE_REGPARM=1"
     CPU="generic" \
     TARGET="linux-glibc" \
     USE_OPENSSL=1 \
+    SSL_LIB="$(pkg-config --libs-only-L openssl11 | sed -e 's/^-L//')" \
+    SSL_INC="$(pkg-config --cflags-only-I openssl11 | sed -e 's/^-I//')" \
     USE_PCRE2=1 \
     USE_ZLIB=1 \
 %if %{with lua}
@@ -167,6 +169,7 @@ exit 0
 %changelog
 * Thu Aug  5 2021 Christian Boenning <christian@boenning.io> - 2.0.23-1
 - Upstream HAProxy 2.0.23
+- Build against OpenSSL 1.1.1
 
 * Mon Feb 01 2021 Christian Boenning <christian@boenning.io> - 2.0.20-1
 - Latest upstream


### PR DESCRIPTION
Update HAProxy to 2.0.23 and build against OpenSSL 1.1.1 from EPEL (#6)

```
# haproxy -vv
HA-Proxy version 2.0.23-cac1631 2021/07/16 - https://haproxy.org/
[...snipp...]
Built with multi-threading support (MAX_THREADS=64, default=6).
Built with OpenSSL version : OpenSSL 1.1.1g FIPS  21 Apr 2020
Running on OpenSSL version : OpenSSL 1.1.1g FIPS  21 Apr 2020
OpenSSL library supports TLS extensions : yes
OpenSSL library supports SNI : yes
OpenSSL library supports : TLSv1.0 TLSv1.1 TLSv1.2 TLSv1.3
[...snipp...]

#
```